### PR TITLE
Set timeouts

### DIFF
--- a/ilm200Sup/ilm200.proto
+++ b/ilm200Sup/ilm200.proto
@@ -1,6 +1,9 @@
 OutTerminator = "\r";
 InTerminator = "\r";
-ReplyTimeout = 2000;
+ReplyTimeout = 5000;
+ReadTimeout = 5000;
+WriteTimeout = 1000;
+LockTimeout = 30000;
 
 getLevel {
     out "@\$1R\$2";


### PR DESCRIPTION
Set timeouts to values tested on EMU.

This gets rid of flickering readings on real hardware. 

https://github.com/ISISComputingGroup/IBEX/issues/5840